### PR TITLE
Support both \r\n and \n

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -440,7 +440,7 @@ class GedcomImport:
 
     def tokenize_from_stream(self, stream: BinaryIO) -> List[Node]:
         """Tokenizes a gedcom steam into a graph."""
-        for line_bytes in stream.read().split(b"\r\n"):
+        for line_bytes in stream.readlines():
             line = line_bytes.strip().decode("utf-8")
             if not line:
                 continue


### PR DESCRIPTION
Python3 use "universal newlines" so user shouldn't have to care.